### PR TITLE
Removes dict comprehension syntax to allow working on python 2.6

### DIFF
--- a/droopy
+++ b/droopy
@@ -216,7 +216,7 @@ class HTTPUploadHandler(httpserver.BaseHTTPRequestHandler):
     def get_case_insensitive_header(self, hdrname, default):
         "Python 2 and 3 differ in header capitalisation!"
         lc_hdrname = hdrname.lower()
-        lc_headers = {h.lower():h for h in self.headers.keys()}
+        lc_headers = dict((h.lower(), h) for h in self.headers.keys())
         if lc_hdrname in lc_headers:
             return self.headers[lc_headers[lc_hdrname]]
         else:


### PR DESCRIPTION
I often connect to old servers where python version is 2.6 and Droopy is a very handy tool to transfer files without the need to setup a ftp server or even a samba server.