### PR TITLE
Make basic authentication work for python 2 & python 3

### DIFF
--- a/droopy
+++ b/droopy
@@ -118,9 +118,12 @@ def check_auth(method):
     def decorated(self, *pargs):
         "Reject if auth fails."
         if self.auth:
-            # TODO: Between minor versions this handles str/bytes differently
             received = self.get_case_insensitive_header('Authorization', None)
-            expected = 'Basic ' + base64.b64encode(self.auth)
+            if sys.version_info >= (3, 0):
+                expected = 'Basic ' + base64.b64encode(
+                            self.auth.encode('utf-8')).decode('utf-8')
+            else:
+                expected = 'Basic ' + base64.b64encode(self.auth)
             # TODO: Timing attack?
             if received != expected:
                 self.send_response(401)


### PR DESCRIPTION
This little fix makes it possible to use droopy with basic authentication (-a) regardless of python 2/3.